### PR TITLE
add vscode 환경설정 제외

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+**/.vscode


### PR DESCRIPTION
vscode 관련 환경설정 파일은 깃에서 제외시켰습니다.